### PR TITLE
fix: move struct declaration of out function to compatible to build on go v1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Check the methods [ported from C#](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1) IEnumerable[T] [here in the enumerable interface](https://github.com/EscanBE/go-ienumerable/blob/main/goe/ienumerable_interface.go) definition
 
-In addition: Check the methods [ported from C#](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerator-1) IEnumerator[T] [here in the enumerator interface](https://github.com/EscanBE/go-ienumerable/blob/main/goe/ienumerator_interface.go) definition
+If you are new to IEnumerable, you can [explore & read examples by Microsoft]([ported from C#](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1)).
 
 ```go
 got := goe.NewIEnumerable[string]("Hello", "World").

--- a/goe/distinct_by.go
+++ b/goe/distinct_by.go
@@ -10,6 +10,11 @@ func (src *enumerable[T]) DistinctBy(keySelector KeySelector[T], optionalEqualsF
 	return src.copyExceptData().withData(unique)
 }
 
+type distinctElementHolder struct {
+	elementIndex int
+	key          any
+}
+
 func distinctByKeySelector[T any](data []T, requiredKeySelector KeySelector[T], optionalEqualityComparer OptionalEqualsFunc[any]) []T {
 	if requiredKeySelector == nil {
 		panic(getErrorKeySelectorNotNil())
@@ -20,15 +25,10 @@ func distinctByKeySelector[T any](data []T, requiredKeySelector KeySelector[T], 
 		equalityComparer = EqualsFunc[any](optionalEqualityComparer)
 	}
 
-	type holder struct {
-		elementIndex int
-		key          any
-	}
-
-	holders := make([]holder, len(data))
+	holders := make([]distinctElementHolder, len(data))
 
 	for i, d := range data {
-		holders[i] = holder{
+		holders[i] = distinctElementHolder{
 			elementIndex: i,
 			key:          requiredKeySelector(d),
 		}
@@ -51,7 +51,7 @@ func distinctByKeySelector[T any](data []T, requiredKeySelector KeySelector[T], 
 		return data
 	}
 
-	uniqueSet := []holder{holders[0]}
+	uniqueSet := []distinctElementHolder{holders[0]}
 
 	for i1 := 1; i1 < len(data); i1++ {
 		ele := holders[i1]

--- a/goe/except_by.go
+++ b/goe/except_by.go
@@ -2,6 +2,11 @@ package goe
 
 import "github.com/EscanBE/go-ienumerable/goe/comparers"
 
+type exceptElementHolder struct {
+	elementIndex int
+	key          any
+}
+
 func (src *enumerable[T]) ExceptBy(second IEnumerable[any], requiredKeySelector KeySelector[T], optionalEqualsFunc OptionalEqualsFunc[any]) IEnumerable[T] {
 	src.assertSrcNonNil()
 	assertSecondIEnumerableNonNil(second)
@@ -12,16 +17,11 @@ func (src *enumerable[T]) ExceptBy(second IEnumerable[any], requiredKeySelector 
 		isEquals = EqualsFunc[any](optionalEqualsFunc)
 	}
 
-	type holder struct {
-		elementIndex int
-		key          any
-	}
-
-	srcHolders := make([]holder, len(src.data))
+	srcHolders := make([]exceptElementHolder, len(src.data))
 	secondData := second.ToArray()
 
 	for i, d1 := range src.data {
-		srcHolders[i] = holder{
+		srcHolders[i] = exceptElementHolder{
 			elementIndex: i,
 			key:          requiredKeySelector(d1),
 		}
@@ -44,7 +44,7 @@ func (src *enumerable[T]) ExceptBy(second IEnumerable[any], requiredKeySelector 
 		return src.copyExceptData().withEmptyData()
 	}
 
-	resultHolders := make([]holder, 0)
+	resultHolders := make([]exceptElementHolder, 0)
 	for _, hSource := range srcHolders {
 		var foundInAnother bool
 		for _, d2 := range secondData {

--- a/goe/intersect_by.go
+++ b/goe/intersect_by.go
@@ -2,6 +2,11 @@ package goe
 
 import "github.com/EscanBE/go-ienumerable/goe/comparers"
 
+type intersectElementHolder struct {
+	key   any
+	index int
+}
+
 func (src *enumerable[T]) IntersectBy(second IEnumerable[T], keySelector KeySelector[T], optionalEqualsFunc OptionalEqualsFunc[any]) IEnumerable[T] {
 	src.assertSrcNonNil()
 	assertSecondIEnumerableNonNil(second)
@@ -17,17 +22,12 @@ func (src *enumerable[T]) IntersectBy(second IEnumerable[T], keySelector KeySele
 	if len(src.data) < 1 || second.Count(nil) < 1 {
 		result = result.withEmptyData()
 	} else {
-		type holder struct {
-			key   any
-			index int
-		}
-
 		intersectIndex := make([]int, 0)
-		sourceKeys := make([]holder, len(src.data))
+		sourceKeys := make([]intersectElementHolder, len(src.data))
 		secondKeys := make([]any, second.Count(nil))
 
 		for i, t := range src.data {
-			sourceKeys[i] = holder{
+			sourceKeys[i] = intersectElementHolder{
 				key:   keySelector(t),
 				index: i,
 			}


### PR DESCRIPTION
Problem is I use 1.20 in development and the issue not happened at all. Today when integrate to project that runs on machine with go v1.19, problem happened.